### PR TITLE
Port published on host with 'ports' command

### DIFF
--- a/compose/orion.yml
+++ b/compose/orion.yml
@@ -17,6 +17,6 @@ orion:
     image: bitergia/fiware-orion:develop
     links:
         - mongodb
-    expose:
-        - "1026"
+    ports:
+        - "1026:1026"
     command: -dbhost mongodb


### PR DESCRIPTION
Changed 'expose' into 'ports' in order to have the same port visible on the host
